### PR TITLE
Upgrade AGP 8.13.2 → 9.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,6 @@ import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec
 
 plugins {
     alias(libs.plugins.comAndroidApplication)
-    alias(libs.plugins.orgJetbrainsKotlinAndroid)
     alias(libs.plugins.comGoogleDevtoolsKsp)
     alias(libs.plugins.ioGitlabArturboschDetekt)
     alias(libs.plugins.orgJetbrainsKotlinPluginCompose)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
     alias(libs.plugins.comAndroidApplication) apply false
-    alias(libs.plugins.orgJetbrainsKotlinAndroid) apply false
     alias(libs.plugins.ioGitlabArturboschDetekt) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ orgJetbrainsKotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.seri
 
 [versions]
 
-androidGradlePlugin = "8.13.2"
+androidGradlePlugin = "9.1.0"
 compose = "1.10.4"
 room = "2.8.4"
 koin = "4.1.1"


### PR DESCRIPTION
## Summary

- Bumps Android Gradle Plugin from **8.13.2** to **9.1.0**
- Removes the now-redundant `org.jetbrains.kotlin.android` plugin — AGP 9 ships built-in Kotlin support

## Breaking changes addressed

| Change | Status |
|---|---|
| Gradle ≥ 8.10 required | ✅ already on 9.4.0 |
| Java ≥ 17 required | ✅ Java 21 |
| `buildConfig` disabled by default | ✅ explicitly enabled |
| Namespace in build.gradle.kts (not AndroidManifest.xml) | ✅ already compliant |
| `org.jetbrains.kotlin.android` no longer allowed | ✅ removed |

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew detekt` — BUILD SUCCESSFUL
- [x] `./gradlew check` (includes unit tests + lint) — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)