### PR TITLE
Fix GPG signing in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,15 +61,20 @@ jobs:
           custom_tag: Release/V${{ steps.version.outputs.version }}_${{ steps.date.outputs.builddate }}
 
       - name: Generate SHA-256 checksum and GPG signature
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           APK="${{ github.workspace }}/app/build/outputs/apk/release/app-release.apk"
           NAME="Daedalus-${{ steps.version.outputs.version }}-${{ steps.versionCode.outputs.versionCode }}.apk"
           CHECKSUM="${{ github.workspace }}/${NAME}.sha256"
 
           echo "$(sha256sum "$APK" | awk '{print $1}')  ${NAME}" > "$CHECKSUM"
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch
+          GNUPGHOME=$(mktemp -d)
+          chmod 700 "$GNUPGHOME"
+          export GNUPGHOME
+          printf '%s\n' "$GPG_PRIVATE_KEY" | gpg --import --batch
           gpg --detach-sign --armor --output "${CHECKSUM}.sig" "$CHECKSUM"
-          gpg --batch --yes --delete-secret-and-public-key 903C3C5DE48798F1
+          rm -rf "$GNUPGHOME"
 
       - name: Upload APK to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
## Summary

- Replace `--delete-secret-and-public-key` with a temporary `GNUPGHOME` directory (`mktemp -d`) that is fully removed via `rm -rf` after signing — no more batch-mode key deletion failures on self-hosted runners where the keyring persists between runs
- Pass `GPG_PRIVATE_KEY` as an env variable instead of interpolating `${{ secrets.GPG_PRIVATE_KEY }}` directly into the shell command

## Test plan

- [ ] Trigger the CD workflow manually via `workflow_dispatch`
- [ ] Verify the `Generate SHA-256 checksum and GPG signature` step completes successfully
- [ ] Verify the `.sig` file is uploaded to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)