### PR TITLE
Update README with title, badge, description, and Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-### Installation via Obtainium
+# Daedalus
+
+[![Get it on Obtainium](https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png)](https://github.com/rjspies/Daedalus/releases/latest)
+
+Daedalus is a minimalist Android app for tracking body weight. Entries are saved with a timestamp, visualised as a chart, and can be exported and imported as CSV. No accounts, no cloud, no ads.
+
+## Installation
 
 [Obtainium](https://github.com/ImranR98/Obtainium) lets you install and update
 Daedalus directly from GitHub releases.
@@ -8,7 +14,7 @@ Daedalus directly from GitHub releases.
 3. Under **APK Filter Regex**, enter: `Daedalus-.*\.apk`
 4. Tap **Add**
 
-#### Verify a release
+### Verify a release
 
 Each release includes a SHA-256 checksum (`.sha256`) and its GPG signature
 (`.sha256.sig`). To verify:
@@ -25,6 +31,8 @@ gpg --verify Daedalus-<version>-<versionCode>.apk.sha256.sig \
 sha256sum -c Daedalus-<version>-<versionCode>.apk.sha256
 ```
 
+## Development
+
 ### Architecture
 
 Daedalus follows a strict three-layer clean architecture:
@@ -38,3 +46,16 @@ Layer dependency rules are enforced automatically by [ArchUnit](https://www.arch
 ### Icons
 
 This app uses [Material Icons Extended](https://developer.android.com/reference/kotlin/androidx/compose/material/icons/package-summary) (Rounded style).
+
+### Build
+
+```shell
+# Build debug APK
+./gradlew assembleDebug
+
+# Run all unit tests
+./gradlew test
+
+# Run lint (detekt)
+./gradlew detekt
+```


### PR DESCRIPTION
## Summary

- Adds `# Daedalus` title and Obtainium badge linking to the latest release
- Adds a short app description (minimalist weight tracking, CSV export/import, no accounts/cloud/ads)
- Restructures existing content under `## Installation` and `## Development` sections
- Adds a `### Build` subsection with the most common Gradle commands

## Test plan

- [ ] README renders correctly on GitHub (title, badge image, all sections visible)
- [ ] Obtainium badge links to `https://github.com/rjspies/Daedalus/releases/latest`
- [ ] Installation steps and Verify block are intact and unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)