### PR TITLE
Bump version to 2.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ ksp = "2.3.6"
 compileSdk = "36"
 targetSdk = "35"
 minSdk = "29"
-versionName = "2.3"
+versionName = "2.4"
 versionCodeOffset = "200000"
 namespace = "com.rjspies.daedalus"
 


### PR DESCRIPTION
## Summary
- Bumps `versionName` from `2.3` to `2.4` in `gradle/libs.versions.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)