### PR TITLE
Move TopAppBar into overview screens

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
@@ -11,11 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ShowChart
 import androidx.compose.material.icons.rounded.History
-import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
@@ -24,8 +22,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
@@ -75,13 +70,8 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
     val isDiagramSelected = currentRoute?.contains(Route.Diagram::class.qualifiedName.orEmpty()) == true
     val isHistorySelected = currentRoute?.contains(Route.History::class.qualifiedName.orEmpty()) == true
 
-    val topBarTitle = if (isHistorySelected) {
-        stringResource(R.string.navigation_top_bar_title_history)
-    } else {
-        stringResource(R.string.navigation_top_bar_title_diagram)
-    }
-
     val hazeState = remember { HazeState() }
+    val onOpenDrawer: () -> Unit = { coroutineScope.launch { drawerState.open() } }
 
     LaunchedEffect(uiState.snackbarVisuals) {
         val visuals = uiState.snackbarVisuals
@@ -146,30 +136,6 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
         },
     ) {
         Scaffold(
-            topBar = {
-                TopAppBar(
-                    title = { Text(topBarTitle) },
-                    modifier = Modifier.hazeEffect(hazeState, HazeMaterials.regular()) {
-                        blurRadius = 40.dp
-                        tints = emptyList()
-                        noiseFactor = 0f
-                        progressive = HazeProgressive.verticalGradient(
-                            easing = LinearEasing,
-                            startIntensity = .25f,
-                            endIntensity = .25f,
-                        )
-                    },
-                    colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
-                    navigationIcon = {
-                        IconButton(onClick = { coroutineScope.launch { drawerState.open() } }) {
-                            Icon(
-                                imageVector = Icons.Rounded.Menu,
-                                contentDescription = stringResource(R.string.navigation_drawer_open_content_description),
-                            )
-                        }
-                    },
-                )
-            },
             snackbarHost = {
                 SnackbarHost(snackbarHostState) { snackbarData ->
                     Snackbar(
@@ -183,7 +149,7 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
                 NavHost(
                     navController = navigationController,
                     startDestination = Route.Diagram,
-                    builder = { navigationGraph(padding) },
+                    builder = { navigationGraph(onOpenDrawer) },
                     modifier = Modifier.hazeSource(hazeState),
                 )
 

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.rjspies.daedalus.presentation
 
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -44,18 +43,15 @@ import com.rjspies.daedalus.presentation.common.Snackbar
 import com.rjspies.daedalus.presentation.common.Spacings
 import com.rjspies.daedalus.presentation.common.VerticalSpacerL
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
+import com.rjspies.daedalus.presentation.common.daedalusHazeEffect
 import com.rjspies.daedalus.presentation.navigation.Route
 import com.rjspies.daedalus.presentation.navigation.navigationGraph
-import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
-import dev.chrisbanes.haze.materials.HazeMaterials
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
     val snackbarHostState = remember { SnackbarHostState() }
@@ -173,7 +169,6 @@ private fun BoxScope.NavigationBarBlur(
     )
 }
 
-@OptIn(ExperimentalHazeMaterialsApi::class)
 @Composable
 private fun Blur(
     height: Dp,
@@ -187,16 +182,6 @@ private fun Blur(
             .fillMaxWidth()
             .height(height)
             .then(modifier)
-            .hazeEffect(hazeState, HazeMaterials.regular()) {
-                blurRadius = 40.dp
-                tints = emptyList()
-                noiseFactor = 0f
-                progressive = HazeProgressive.verticalGradient(
-                    easing = LinearEasing,
-                    startIntensity = .25f,
-                    endIntensity = .25f,
-                    endY = heightPx,
-                )
-            },
+            .daedalusHazeEffect(hazeState, endY = heightPx),
     )
 }

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
@@ -29,10 +29,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -175,13 +173,11 @@ private fun Blur(
     hazeState: HazeState,
     modifier: Modifier = Modifier,
 ) {
-    val heightPx = with(LocalDensity.current) { height.toPx() }
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(height)
             .then(modifier)
-            .daedalusHazeEffect(hazeState, endY = heightPx),
+            .daedalusHazeEffect(hazeState),
     )
 }

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/HazeExtensions.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/HazeExtensions.kt
@@ -11,9 +11,7 @@ import dev.chrisbanes.haze.materials.HazeMaterials
 
 @Composable
 @OptIn(ExperimentalHazeMaterialsApi::class)
-fun Modifier.daedalusHazeEffect(
-    state: HazeState,
-): Modifier {
+fun Modifier.daedalusHazeEffect(state: HazeState): Modifier {
     val material = HazeMaterials.regular()
     return this then Modifier.hazeEffect(state, material) {
         blurRadius = 20.dp

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/HazeExtensions.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/HazeExtensions.kt
@@ -1,0 +1,39 @@
+package com.rjspies.daedalus.presentation.common
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+
+@Composable
+@OptIn(ExperimentalHazeMaterialsApi::class)
+fun Modifier.daedalusHazeEffect(
+    state: HazeState,
+    endY: Float? = null,
+): Modifier {
+    val material = HazeMaterials.regular()
+    return this then Modifier.hazeEffect(state, material) {
+        blurRadius = 40.dp
+        tints = emptyList()
+        noiseFactor = 0f
+        progressive = if (endY != null) {
+            HazeProgressive.verticalGradient(
+                easing = LinearEasing,
+                startIntensity = .25f,
+                endIntensity = .25f,
+                endY = endY,
+            )
+        } else {
+            HazeProgressive.verticalGradient(
+                easing = LinearEasing,
+                startIntensity = .25f,
+                endIntensity = .25f,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/HazeExtensions.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/HazeExtensions.kt
@@ -1,6 +1,5 @@
 package com.rjspies.daedalus.presentation.common
 
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -14,26 +13,17 @@ import dev.chrisbanes.haze.materials.HazeMaterials
 @OptIn(ExperimentalHazeMaterialsApi::class)
 fun Modifier.daedalusHazeEffect(
     state: HazeState,
-    endY: Float? = null,
 ): Modifier {
     val material = HazeMaterials.regular()
     return this then Modifier.hazeEffect(state, material) {
-        blurRadius = 40.dp
+        blurRadius = 20.dp
         tints = emptyList()
         noiseFactor = 0f
-        progressive = if (endY != null) {
-            HazeProgressive.verticalGradient(
-                easing = LinearEasing,
-                startIntensity = .25f,
-                endIntensity = .25f,
-                endY = endY,
-            )
-        } else {
-            HazeProgressive.verticalGradient(
-                easing = LinearEasing,
-                startIntensity = .25f,
-                endIntensity = .25f,
-            )
-        }
+        // HazeEffectScope has no direct intensity property; intensity is only configurable
+        // via HazeProgressive. Equal start and end values result in a constant intensity.
+        progressive = HazeProgressive.verticalGradient(
+            startIntensity = .5f,
+            endIntensity = .5f,
+        )
     }
 }

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/OverviewScreenContent.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/OverviewScreenContent.kt
@@ -1,0 +1,59 @@
+package com.rjspies.daedalus.presentation.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Menu
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import com.rjspies.daedalus.R
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OverviewScreenContent(
+    title: String,
+    onOpenDrawer: () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    val hazeState = remember { HazeState() }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(title) },
+                modifier = Modifier.daedalusHazeEffect(hazeState),
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
+                navigationIcon = {
+                    IconButton(onClick = onOpenDrawer) {
+                        Icon(
+                            imageVector = Icons.Rounded.Menu,
+                            contentDescription = stringResource(R.string.navigation_drawer_open_content_description),
+                        )
+                    }
+                },
+            )
+        },
+        content = { scaffoldPadding ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .hazeSource(hazeState),
+            ) {
+                content(scaffoldPadding)
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,16 +22,22 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Addchart
+import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material.icons.rounded.Timeline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,6 +45,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -75,6 +81,12 @@ import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.WeightChartEntry
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
 import com.rjspies.daedalus.presentation.common.verticalSpacingM
+import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import org.koin.androidx.compose.koinViewModel
@@ -82,173 +94,209 @@ import org.koin.androidx.compose.koinViewModel
 private const val FULL_CORNER_RADIUS_PERCENT = 50
 
 @Suppress("LongMethod")
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
 @Composable
 fun WeightDiagramScreen(
-    scaffoldPadding: PaddingValues,
+    onOpenDrawer: () -> Unit,
     viewModel: WeightDiagramViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val hazeState = remember { HazeState() }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(scaffoldPadding)
-            .padding(bottom = Spacings.XXL),
-    ) {
-        if (uiState.shouldShowInsertWeightDialog) {
-            val focusRequester = remember { FocusRequester() }
-            AlertDialog(
-                onDismissRequest = {
-                    if (uiState.isInsertWeightDialogDismissable) {
-                        viewModel.onEvent(WeightDiagramViewModel.Event.CloseInsertWeightDialog)
-                    }
-                },
-                confirmButton = {
-                    TextButton(
-                        onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
-                        content = {
-                            Text(stringResource(R.string.insert_weight_insert_button_text))
-                        },
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.navigation_top_bar_title_diagram)) },
+                modifier = Modifier.hazeEffect(hazeState, HazeMaterials.regular()) {
+                    blurRadius = 40.dp
+                    tints = emptyList()
+                    noiseFactor = 0f
+                    progressive = HazeProgressive.verticalGradient(
+                        easing = LinearEasing,
+                        startIntensity = .25f,
+                        endIntensity = .25f,
                     )
                 },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .imePadding(),
-                icon = { Icon(rememberVectorPainter(Icons.Rounded.Addchart), contentDescription = null) },
-                title = { Text(stringResource(R.string.insert_weight_dialog_title)) },
-                text = {
-                    LaunchedEffect(Unit) {
-                        focusRequester.requestFocus()
-                    }
-
-                    Column {
-                        OutlinedTextField(
-                            value = uiState.insertWeightDialogCurrentWeight.orEmpty(),
-                            onValueChange = { viewModel.onEvent(WeightDiagramViewModel.Event.SetCurrentWeight(it)) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .focusRequester(focusRequester),
-                            label = { Text(stringResource(R.string.insert_weight_weight_text_field_label)) },
-                            shape = MaterialTheme.shapes.medium,
-                            supportingText = {
-                                if (uiState.insertWeightDialogError != null) {
-                                    Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message_error))
-                                } else {
-                                    Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message))
-                                }
-                            },
-                            keyboardOptions = KeyboardOptions(
-                                keyboardType = KeyboardType.Decimal,
-                                imeAction = ImeAction.Done,
-                            ),
-                            keyboardActions = KeyboardActions(
-                                onDone = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
-                            ),
-                        )
-
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .animateContentSize(
-                                    animationSpec = tween(
-                                        durationMillis = 35,
-                                        easing = LinearEasing,
-                                    ),
-                                ),
-                            content = {
-                                if (uiState.isInsertWeightDialogLoading) {
-                                    VerticalSpacerXS()
-                                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                                }
-                            },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
+                navigationIcon = {
+                    IconButton(onClick = onOpenDrawer) {
+                        Icon(
+                            imageVector = Icons.Rounded.Menu,
+                            contentDescription = stringResource(R.string.navigation_drawer_open_content_description),
                         )
                     }
                 },
             )
-        }
-
-        val exportData = uiState.exportPrompt
-        if (exportData != null) {
-            val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportData.mimeType)) {
-                viewModel.onEvent(WeightDiagramViewModel.Event.PathChosen(it?.toString()))
-            }
-
-            LaunchedEffect(Unit) {
-                launcher.launch(exportData.fileName)
-            }
-        }
-
-        val importData = uiState.importPrompt
-        if (importData != null) {
-            val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
-                viewModel.onEvent(WeightDiagramViewModel.Event.ImportPathChosen(it?.toString()))
-            }
-
-            LaunchedEffect(Unit) {
-                importLauncher.launch(arrayOf(importData.mimeType))
-            }
-        }
-
-        if (uiState.weights.isNotEmpty()) {
-            Column {
-                Text(
-                    text = stringResource(R.string.weight_diagram_title),
-                    modifier = Modifier.horizontalSpacingM(),
-                    style = MaterialTheme.typography.displayMedium,
-                )
-                Box(Modifier.horizontalSpacingM()) { Chart(uiState.weights) }
-            }
-            VerticalSpacerM()
-            WeightStatisticRow(
-                thirtyDayAverage = uiState.thirtyDayAverageWeight,
-                latestWeight = uiState.latestWeight,
-            )
-            Spacer(Modifier.weight(1f))
-        } else {
-            Spacer(Modifier.weight(1f))
-            EmptyScreen(
-                painter = rememberVectorPainter(Icons.Rounded.Timeline),
-                contentDescription = stringResource(R.string.weight_diagram_empty_screen_content_description),
-                title = stringResource(R.string.weight_diagram_empty_screen_title),
-                subtitle = stringResource(R.string.weight_diagram_empty_screen_subtitle),
+        },
+        content = { scaffoldPadding ->
+            Box(
                 modifier = Modifier
-                    .verticalSpacingM()
-                    .horizontalSpacingM(),
-            )
-            Spacer(Modifier.weight(1f))
-        }
-
-        VerticalSpacerL()
-        Column(verticalArrangement = Arrangement.spacedBy(Spacings.XS)) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalSpacingM(),
-                horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
+                    .fillMaxSize()
+                    .hazeSource(hazeState),
             ) {
-                OutlinedButton(
-                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ImportClicked) },
-                    modifier = Modifier.weight(1f),
-                    content = { Text(stringResource(R.string.weight_diagram_button_import_weights_title)) },
-                    enabled = !uiState.isImporting,
-                )
-                OutlinedButton(
-                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ExportClicked) },
-                    modifier = Modifier.weight(1f),
-                    content = { Text(stringResource(R.string.weight_diagram_button_export_weights_title)) },
-                    enabled = !uiState.isExporting,
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(scaffoldPadding)
+                        .padding(bottom = Spacings.XXL),
+                ) {
+                    if (uiState.shouldShowInsertWeightDialog) {
+                        val focusRequester = remember { FocusRequester() }
+                        AlertDialog(
+                            onDismissRequest = {
+                                if (uiState.isInsertWeightDialogDismissable) {
+                                    viewModel.onEvent(WeightDiagramViewModel.Event.CloseInsertWeightDialog)
+                                }
+                            },
+                            confirmButton = {
+                                TextButton(
+                                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
+                                    content = {
+                                        Text(stringResource(R.string.insert_weight_insert_button_text))
+                                    },
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .imePadding(),
+                            icon = { Icon(rememberVectorPainter(Icons.Rounded.Addchart), contentDescription = null) },
+                            title = { Text(stringResource(R.string.insert_weight_dialog_title)) },
+                            text = {
+                                LaunchedEffect(Unit) {
+                                    focusRequester.requestFocus()
+                                }
+
+                                Column {
+                                    OutlinedTextField(
+                                        value = uiState.insertWeightDialogCurrentWeight.orEmpty(),
+                                        onValueChange = { viewModel.onEvent(WeightDiagramViewModel.Event.SetCurrentWeight(it)) },
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .focusRequester(focusRequester),
+                                        label = { Text(stringResource(R.string.insert_weight_weight_text_field_label)) },
+                                        shape = MaterialTheme.shapes.medium,
+                                        supportingText = {
+                                            if (uiState.insertWeightDialogError != null) {
+                                                Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message_error))
+                                            } else {
+                                                Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message))
+                                            }
+                                        },
+                                        keyboardOptions = KeyboardOptions(
+                                            keyboardType = KeyboardType.Decimal,
+                                            imeAction = ImeAction.Done,
+                                        ),
+                                        keyboardActions = KeyboardActions(
+                                            onDone = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
+                                        ),
+                                    )
+
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .animateContentSize(
+                                                animationSpec = tween(
+                                                    durationMillis = 35,
+                                                    easing = LinearEasing,
+                                                ),
+                                            ),
+                                        content = {
+                                            if (uiState.isInsertWeightDialogLoading) {
+                                                VerticalSpacerXS()
+                                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                                            }
+                                        },
+                                    )
+                                }
+                            },
+                        )
+                    }
+
+                    val exportData = uiState.exportPrompt
+                    if (exportData != null) {
+                        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportData.mimeType)) {
+                            viewModel.onEvent(WeightDiagramViewModel.Event.PathChosen(it?.toString()))
+                        }
+
+                        LaunchedEffect(Unit) {
+                            launcher.launch(exportData.fileName)
+                        }
+                    }
+
+                    val importData = uiState.importPrompt
+                    if (importData != null) {
+                        val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
+                            viewModel.onEvent(WeightDiagramViewModel.Event.ImportPathChosen(it?.toString()))
+                        }
+
+                        LaunchedEffect(Unit) {
+                            importLauncher.launch(arrayOf(importData.mimeType))
+                        }
+                    }
+
+                    if (uiState.weights.isNotEmpty()) {
+                        Column {
+                            Text(
+                                text = stringResource(R.string.weight_diagram_title),
+                                modifier = Modifier.horizontalSpacingM(),
+                                style = MaterialTheme.typography.displayMedium,
+                            )
+                            Box(Modifier.horizontalSpacingM()) { Chart(uiState.weights) }
+                        }
+                        VerticalSpacerM()
+                        WeightStatisticRow(
+                            thirtyDayAverage = uiState.thirtyDayAverageWeight,
+                            latestWeight = uiState.latestWeight,
+                        )
+                        Spacer(Modifier.weight(1f))
+                    } else {
+                        Spacer(Modifier.weight(1f))
+                        EmptyScreen(
+                            painter = rememberVectorPainter(Icons.Rounded.Timeline),
+                            contentDescription = stringResource(R.string.weight_diagram_empty_screen_content_description),
+                            title = stringResource(R.string.weight_diagram_empty_screen_title),
+                            subtitle = stringResource(R.string.weight_diagram_empty_screen_subtitle),
+                            modifier = Modifier
+                                .verticalSpacingM()
+                                .horizontalSpacingM(),
+                        )
+                        Spacer(Modifier.weight(1f))
+                    }
+
+                    VerticalSpacerL()
+                    Column(verticalArrangement = Arrangement.spacedBy(Spacings.XS)) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalSpacingM(),
+                            horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
+                        ) {
+                            OutlinedButton(
+                                onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ImportClicked) },
+                                modifier = Modifier.weight(1f),
+                                content = { Text(stringResource(R.string.weight_diagram_button_import_weights_title)) },
+                                enabled = !uiState.isImporting,
+                            )
+                            OutlinedButton(
+                                onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ExportClicked) },
+                                modifier = Modifier.weight(1f),
+                                content = { Text(stringResource(R.string.weight_diagram_button_export_weights_title)) },
+                                enabled = !uiState.isExporting,
+                            )
+                        }
+                        Button(
+                            onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ShowInsertWeightDialog) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalSpacingM(),
+                            content = { Text(stringResource(R.string.weight_diagram_button_insert_weight_title)) },
+                        )
+                    }
+                }
             }
-            Button(
-                onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ShowInsertWeightDialog) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalSpacingM(),
-                content = { Text(stringResource(R.string.weight_diagram_button_insert_weight_title)) },
-            )
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
@@ -80,13 +80,10 @@ import com.rjspies.daedalus.presentation.common.VerticalSpacerM
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.WeightChartEntry
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
+import com.rjspies.daedalus.presentation.common.daedalusHazeEffect
 import com.rjspies.daedalus.presentation.common.verticalSpacingM
-import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
-import dev.chrisbanes.haze.materials.HazeMaterials
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import org.koin.androidx.compose.koinViewModel
@@ -94,7 +91,7 @@ import org.koin.androidx.compose.koinViewModel
 private const val FULL_CORNER_RADIUS_PERCENT = 50
 
 @Suppress("LongMethod")
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeightDiagramScreen(
     onOpenDrawer: () -> Unit,
@@ -107,16 +104,7 @@ fun WeightDiagramScreen(
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(stringResource(R.string.navigation_top_bar_title_diagram)) },
-                modifier = Modifier.hazeEffect(hazeState, HazeMaterials.regular()) {
-                    blurRadius = 40.dp
-                    tints = emptyList()
-                    noiseFactor = 0f
-                    progressive = HazeProgressive.verticalGradient(
-                        easing = LinearEasing,
-                        startIntensity = .25f,
-                        endIntensity = .25f,
-                    )
-                },
+                modifier = Modifier.daedalusHazeEffect(hazeState),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
                 navigationIcon = {
                     IconButton(onClick = onOpenDrawer) {

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
@@ -22,22 +22,16 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Addchart
-import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material.icons.rounded.Timeline
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -45,7 +39,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -74,16 +67,14 @@ import com.patrykandpatrick.vico.compose.common.component.rememberShapeComponent
 import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
 import com.rjspies.daedalus.R
 import com.rjspies.daedalus.presentation.common.EmptyScreen
+import com.rjspies.daedalus.presentation.common.OverviewScreenContent
 import com.rjspies.daedalus.presentation.common.Spacings
 import com.rjspies.daedalus.presentation.common.VerticalSpacerL
 import com.rjspies.daedalus.presentation.common.VerticalSpacerM
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.WeightChartEntry
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
-import com.rjspies.daedalus.presentation.common.daedalusHazeEffect
 import com.rjspies.daedalus.presentation.common.verticalSpacingM
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeSource
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import org.koin.androidx.compose.koinViewModel
@@ -91,200 +82,178 @@ import org.koin.androidx.compose.koinViewModel
 private const val FULL_CORNER_RADIUS_PERCENT = 50
 
 @Suppress("LongMethod")
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeightDiagramScreen(
     onOpenDrawer: () -> Unit,
     viewModel: WeightDiagramViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val hazeState = remember { HazeState() }
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text(stringResource(R.string.navigation_top_bar_title_diagram)) },
-                modifier = Modifier.daedalusHazeEffect(hazeState),
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
-                navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
-                        Icon(
-                            imageVector = Icons.Rounded.Menu,
-                            contentDescription = stringResource(R.string.navigation_drawer_open_content_description),
+    OverviewScreenContent(
+        title = stringResource(R.string.navigation_top_bar_title_diagram),
+        onOpenDrawer = onOpenDrawer,
+    ) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(scaffoldPadding)
+                .padding(bottom = Spacings.XXL),
+        ) {
+            if (uiState.shouldShowInsertWeightDialog) {
+                val focusRequester = remember { FocusRequester() }
+                AlertDialog(
+                    onDismissRequest = {
+                        if (uiState.isInsertWeightDialogDismissable) {
+                            viewModel.onEvent(WeightDiagramViewModel.Event.CloseInsertWeightDialog)
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(
+                            onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
+                            content = {
+                                Text(stringResource(R.string.insert_weight_insert_button_text))
+                            },
                         )
-                    }
-                },
-            )
-        },
-        content = { scaffoldPadding ->
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .hazeSource(hazeState),
-            ) {
-                Column(
+                    },
                     modifier = Modifier
-                        .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
-                        .padding(scaffoldPadding)
-                        .padding(bottom = Spacings.XXL),
-                ) {
-                    if (uiState.shouldShowInsertWeightDialog) {
-                        val focusRequester = remember { FocusRequester() }
-                        AlertDialog(
-                            onDismissRequest = {
-                                if (uiState.isInsertWeightDialogDismissable) {
-                                    viewModel.onEvent(WeightDiagramViewModel.Event.CloseInsertWeightDialog)
-                                }
-                            },
-                            confirmButton = {
-                                TextButton(
-                                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
-                                    content = {
-                                        Text(stringResource(R.string.insert_weight_insert_button_text))
-                                    },
-                                )
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .imePadding(),
-                            icon = { Icon(rememberVectorPainter(Icons.Rounded.Addchart), contentDescription = null) },
-                            title = { Text(stringResource(R.string.insert_weight_dialog_title)) },
-                            text = {
-                                LaunchedEffect(Unit) {
-                                    focusRequester.requestFocus()
-                                }
-
-                                Column {
-                                    OutlinedTextField(
-                                        value = uiState.insertWeightDialogCurrentWeight.orEmpty(),
-                                        onValueChange = { viewModel.onEvent(WeightDiagramViewModel.Event.SetCurrentWeight(it)) },
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .focusRequester(focusRequester),
-                                        label = { Text(stringResource(R.string.insert_weight_weight_text_field_label)) },
-                                        shape = MaterialTheme.shapes.medium,
-                                        supportingText = {
-                                            if (uiState.insertWeightDialogError != null) {
-                                                Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message_error))
-                                            } else {
-                                                Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message))
-                                            }
-                                        },
-                                        keyboardOptions = KeyboardOptions(
-                                            keyboardType = KeyboardType.Decimal,
-                                            imeAction = ImeAction.Done,
-                                        ),
-                                        keyboardActions = KeyboardActions(
-                                            onDone = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
-                                        ),
-                                    )
-
-                                    Column(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .animateContentSize(
-                                                animationSpec = tween(
-                                                    durationMillis = 35,
-                                                    easing = LinearEasing,
-                                                ),
-                                            ),
-                                        content = {
-                                            if (uiState.isInsertWeightDialogLoading) {
-                                                VerticalSpacerXS()
-                                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                                            }
-                                        },
-                                    )
-                                }
-                            },
-                        )
-                    }
-
-                    val exportData = uiState.exportPrompt
-                    if (exportData != null) {
-                        val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportData.mimeType)) {
-                            viewModel.onEvent(WeightDiagramViewModel.Event.PathChosen(it?.toString()))
-                        }
-
+                        .fillMaxWidth()
+                        .imePadding(),
+                    icon = { Icon(rememberVectorPainter(Icons.Rounded.Addchart), contentDescription = null) },
+                    title = { Text(stringResource(R.string.insert_weight_dialog_title)) },
+                    text = {
                         LaunchedEffect(Unit) {
-                            launcher.launch(exportData.fileName)
-                        }
-                    }
-
-                    val importData = uiState.importPrompt
-                    if (importData != null) {
-                        val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
-                            viewModel.onEvent(WeightDiagramViewModel.Event.ImportPathChosen(it?.toString()))
+                            focusRequester.requestFocus()
                         }
 
-                        LaunchedEffect(Unit) {
-                            importLauncher.launch(arrayOf(importData.mimeType))
-                        }
-                    }
-
-                    if (uiState.weights.isNotEmpty()) {
                         Column {
-                            Text(
-                                text = stringResource(R.string.weight_diagram_title),
-                                modifier = Modifier.horizontalSpacingM(),
-                                style = MaterialTheme.typography.displayMedium,
+                            OutlinedTextField(
+                                value = uiState.insertWeightDialogCurrentWeight.orEmpty(),
+                                onValueChange = { viewModel.onEvent(WeightDiagramViewModel.Event.SetCurrentWeight(it)) },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .focusRequester(focusRequester),
+                                label = { Text(stringResource(R.string.insert_weight_weight_text_field_label)) },
+                                shape = MaterialTheme.shapes.medium,
+                                supportingText = {
+                                    if (uiState.insertWeightDialogError != null) {
+                                        Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message_error))
+                                    } else {
+                                        Text(stringResource(R.string.insert_weight_weight_text_field_supporting_message))
+                                    }
+                                },
+                                keyboardOptions = KeyboardOptions(
+                                    keyboardType = KeyboardType.Decimal,
+                                    imeAction = ImeAction.Done,
+                                ),
+                                keyboardActions = KeyboardActions(
+                                    onDone = { viewModel.onEvent(WeightDiagramViewModel.Event.InsertCurrentWeight) },
+                                ),
                             )
-                            Box(Modifier.horizontalSpacingM()) { Chart(uiState.weights) }
-                        }
-                        VerticalSpacerM()
-                        WeightStatisticRow(
-                            thirtyDayAverage = uiState.thirtyDayAverageWeight,
-                            latestWeight = uiState.latestWeight,
-                        )
-                        Spacer(Modifier.weight(1f))
-                    } else {
-                        Spacer(Modifier.weight(1f))
-                        EmptyScreen(
-                            painter = rememberVectorPainter(Icons.Rounded.Timeline),
-                            contentDescription = stringResource(R.string.weight_diagram_empty_screen_content_description),
-                            title = stringResource(R.string.weight_diagram_empty_screen_title),
-                            subtitle = stringResource(R.string.weight_diagram_empty_screen_subtitle),
-                            modifier = Modifier
-                                .verticalSpacingM()
-                                .horizontalSpacingM(),
-                        )
-                        Spacer(Modifier.weight(1f))
-                    }
 
-                    VerticalSpacerL()
-                    Column(verticalArrangement = Arrangement.spacedBy(Spacings.XS)) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .horizontalSpacingM(),
-                            horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
-                        ) {
-                            OutlinedButton(
-                                onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ImportClicked) },
-                                modifier = Modifier.weight(1f),
-                                content = { Text(stringResource(R.string.weight_diagram_button_import_weights_title)) },
-                                enabled = !uiState.isImporting,
-                            )
-                            OutlinedButton(
-                                onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ExportClicked) },
-                                modifier = Modifier.weight(1f),
-                                content = { Text(stringResource(R.string.weight_diagram_button_export_weights_title)) },
-                                enabled = !uiState.isExporting,
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .animateContentSize(
+                                        animationSpec = tween(
+                                            durationMillis = 35,
+                                            easing = LinearEasing,
+                                        ),
+                                    ),
+                                content = {
+                                    if (uiState.isInsertWeightDialogLoading) {
+                                        VerticalSpacerXS()
+                                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                                    }
+                                },
                             )
                         }
-                        Button(
-                            onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ShowInsertWeightDialog) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .horizontalSpacingM(),
-                            content = { Text(stringResource(R.string.weight_diagram_button_insert_weight_title)) },
-                        )
-                    }
+                    },
+                )
+            }
+
+            val exportData = uiState.exportPrompt
+            if (exportData != null) {
+                val launcher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportData.mimeType)) {
+                    viewModel.onEvent(WeightDiagramViewModel.Event.PathChosen(it?.toString()))
+                }
+
+                LaunchedEffect(Unit) {
+                    launcher.launch(exportData.fileName)
                 }
             }
-        },
-    )
+
+            val importData = uiState.importPrompt
+            if (importData != null) {
+                val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
+                    viewModel.onEvent(WeightDiagramViewModel.Event.ImportPathChosen(it?.toString()))
+                }
+
+                LaunchedEffect(Unit) {
+                    importLauncher.launch(arrayOf(importData.mimeType))
+                }
+            }
+
+            if (uiState.weights.isNotEmpty()) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.weight_diagram_title),
+                        modifier = Modifier.horizontalSpacingM(),
+                        style = MaterialTheme.typography.displayMedium,
+                    )
+                    Box(Modifier.horizontalSpacingM()) { Chart(uiState.weights) }
+                }
+                VerticalSpacerM()
+                WeightStatisticRow(
+                    thirtyDayAverage = uiState.thirtyDayAverageWeight,
+                    latestWeight = uiState.latestWeight,
+                )
+                Spacer(Modifier.weight(1f))
+            } else {
+                Spacer(Modifier.weight(1f))
+                EmptyScreen(
+                    painter = rememberVectorPainter(Icons.Rounded.Timeline),
+                    contentDescription = stringResource(R.string.weight_diagram_empty_screen_content_description),
+                    title = stringResource(R.string.weight_diagram_empty_screen_title),
+                    subtitle = stringResource(R.string.weight_diagram_empty_screen_subtitle),
+                    modifier = Modifier
+                        .verticalSpacingM()
+                        .horizontalSpacingM(),
+                )
+                Spacer(Modifier.weight(1f))
+            }
+
+            VerticalSpacerL()
+            Column(verticalArrangement = Arrangement.spacedBy(Spacings.XS)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalSpacingM(),
+                    horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
+                ) {
+                    OutlinedButton(
+                        onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ImportClicked) },
+                        modifier = Modifier.weight(1f),
+                        content = { Text(stringResource(R.string.weight_diagram_button_import_weights_title)) },
+                        enabled = !uiState.isImporting,
+                    )
+                    OutlinedButton(
+                        onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ExportClicked) },
+                        modifier = Modifier.weight(1f),
+                        content = { Text(stringResource(R.string.weight_diagram_button_export_weights_title)) },
+                        enabled = !uiState.isExporting,
+                    )
+                }
+                Button(
+                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ShowInsertWeightDialog) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalSpacingM(),
+                    content = { Text(stringResource(R.string.weight_diagram_button_insert_weight_title)) },
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
@@ -1,6 +1,5 @@
 package com.rjspies.daedalus.presentation.history
 
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -36,16 +35,13 @@ import com.rjspies.daedalus.presentation.common.Spacings
 import com.rjspies.daedalus.presentation.common.VerticalSpacerS
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
+import com.rjspies.daedalus.presentation.common.daedalusHazeEffect
 import com.rjspies.daedalus.presentation.common.verticalSpacingXXL
-import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
-import dev.chrisbanes.haze.materials.HazeMaterials
 import org.koin.androidx.compose.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeightHistoryScreen(
     onOpenDrawer: () -> Unit,
@@ -58,16 +54,7 @@ fun WeightHistoryScreen(
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(stringResource(R.string.navigation_top_bar_title_history)) },
-                modifier = Modifier.hazeEffect(hazeState, HazeMaterials.regular()) {
-                    blurRadius = 40.dp
-                    tints = emptyList()
-                    noiseFactor = 0f
-                    progressive = HazeProgressive.verticalGradient(
-                        easing = LinearEasing,
-                        startIntensity = .25f,
-                        endIntensity = .25f,
-                    )
-                },
+                modifier = Modifier.daedalusHazeEffect(hazeState),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
                 navigationIcon = {
                     IconButton(onClick = onOpenDrawer) {

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
@@ -1,5 +1,6 @@
 package com.rjspies.daedalus.presentation.history
 
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,14 +11,23 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FormatListNumbered
+import androidx.compose.material.icons.rounded.Menu
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rjspies.daedalus.R
 import com.rjspies.daedalus.domain.Weight
@@ -27,34 +37,72 @@ import com.rjspies.daedalus.presentation.common.VerticalSpacerS
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
 import com.rjspies.daedalus.presentation.common.verticalSpacingXXL
+import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
 @Composable
 fun WeightHistoryScreen(
-    scaffoldPadding: PaddingValues,
+    onOpenDrawer: () -> Unit,
     viewModel: WeightHistoryViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val hazeState = remember { HazeState() }
 
-    if (uiState.weights.isNotEmpty()) {
-        Weights(
-            weights = uiState.weights,
-            scaffoldPadding = scaffoldPadding,
-        )
-    } else {
-        EmptyScreen(
-            painter = rememberVectorPainter(Icons.Rounded.FormatListNumbered),
-            contentDescription = stringResource(R.string.weight_history_empty_screen_content_description),
-            title = stringResource(R.string.weight_history_empty_screen_title),
-            subtitle = stringResource(R.string.weight_history_empty_screen_subtitle),
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(scaffoldPadding)
-                .verticalSpacingXXL()
-                .horizontalSpacingM(),
-        )
-    }
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.navigation_top_bar_title_history)) },
+                modifier = Modifier.hazeEffect(hazeState, HazeMaterials.regular()) {
+                    blurRadius = 40.dp
+                    tints = emptyList()
+                    noiseFactor = 0f
+                    progressive = HazeProgressive.verticalGradient(
+                        easing = LinearEasing,
+                        startIntensity = .25f,
+                        endIntensity = .25f,
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
+                navigationIcon = {
+                    IconButton(onClick = onOpenDrawer) {
+                        Icon(
+                            imageVector = Icons.Rounded.Menu,
+                            contentDescription = stringResource(R.string.navigation_drawer_open_content_description),
+                        )
+                    }
+                },
+            )
+        },
+        content = { scaffoldPadding ->
+            if (uiState.weights.isNotEmpty()) {
+                Weights(
+                    weights = uiState.weights,
+                    scaffoldPadding = scaffoldPadding,
+                    hazeState = hazeState,
+                )
+            } else {
+                EmptyScreen(
+                    painter = rememberVectorPainter(Icons.Rounded.FormatListNumbered),
+                    contentDescription = stringResource(R.string.weight_history_empty_screen_content_description),
+                    title = stringResource(R.string.weight_history_empty_screen_title),
+                    subtitle = stringResource(R.string.weight_history_empty_screen_subtitle),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .hazeSource(hazeState)
+                        .verticalScroll(rememberScrollState())
+                        .padding(scaffoldPadding)
+                        .verticalSpacingXXL()
+                        .horizontalSpacingM(),
+                )
+            }
+        },
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -62,9 +110,12 @@ fun WeightHistoryScreen(
 private fun Weights(
     weights: List<Weight>,
     scaffoldPadding: PaddingValues,
+    hazeState: HazeState,
 ) {
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .hazeSource(hazeState),
         contentPadding = PaddingValues(
             top = scaffoldPadding.calculateTopPadding(),
             end = Spacings.M,

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
@@ -10,86 +10,57 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FormatListNumbered
-import androidx.compose.material.icons.rounded.Menu
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rjspies.daedalus.R
 import com.rjspies.daedalus.domain.Weight
 import com.rjspies.daedalus.presentation.common.EmptyScreen
+import com.rjspies.daedalus.presentation.common.OverviewScreenContent
 import com.rjspies.daedalus.presentation.common.Spacings
 import com.rjspies.daedalus.presentation.common.VerticalSpacerS
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
-import com.rjspies.daedalus.presentation.common.daedalusHazeEffect
 import com.rjspies.daedalus.presentation.common.verticalSpacingXXL
-import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeSource
 import org.koin.androidx.compose.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WeightHistoryScreen(
     onOpenDrawer: () -> Unit,
     viewModel: WeightHistoryViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val hazeState = remember { HazeState() }
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text(stringResource(R.string.navigation_top_bar_title_history)) },
-                modifier = Modifier.daedalusHazeEffect(hazeState),
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
-                navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
-                        Icon(
-                            imageVector = Icons.Rounded.Menu,
-                            contentDescription = stringResource(R.string.navigation_drawer_open_content_description),
-                        )
-                    }
-                },
+    OverviewScreenContent(
+        title = stringResource(R.string.navigation_top_bar_title_history),
+        onOpenDrawer = onOpenDrawer,
+    ) { scaffoldPadding ->
+        if (uiState.weights.isNotEmpty()) {
+            Weights(
+                weights = uiState.weights,
+                scaffoldPadding = scaffoldPadding,
             )
-        },
-        content = { scaffoldPadding ->
-            if (uiState.weights.isNotEmpty()) {
-                Weights(
-                    weights = uiState.weights,
-                    scaffoldPadding = scaffoldPadding,
-                    hazeState = hazeState,
-                )
-            } else {
-                EmptyScreen(
-                    painter = rememberVectorPainter(Icons.Rounded.FormatListNumbered),
-                    contentDescription = stringResource(R.string.weight_history_empty_screen_content_description),
-                    title = stringResource(R.string.weight_history_empty_screen_title),
-                    subtitle = stringResource(R.string.weight_history_empty_screen_subtitle),
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .hazeSource(hazeState)
-                        .verticalScroll(rememberScrollState())
-                        .padding(scaffoldPadding)
-                        .verticalSpacingXXL()
-                        .horizontalSpacingM(),
-                )
-            }
-        },
-    )
+        } else {
+            EmptyScreen(
+                painter = rememberVectorPainter(Icons.Rounded.FormatListNumbered),
+                contentDescription = stringResource(R.string.weight_history_empty_screen_content_description),
+                title = stringResource(R.string.weight_history_empty_screen_title),
+                subtitle = stringResource(R.string.weight_history_empty_screen_subtitle),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(scaffoldPadding)
+                    .verticalSpacingXXL()
+                    .horizontalSpacingM(),
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -97,12 +68,9 @@ fun WeightHistoryScreen(
 private fun Weights(
     weights: List<Weight>,
     scaffoldPadding: PaddingValues,
-    hazeState: HazeState,
 ) {
     LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .hazeSource(hazeState),
+        modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(
             top = scaffoldPadding.calculateTopPadding(),
             end = Spacings.M,

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/NavigationGraph.kt
@@ -1,16 +1,15 @@
 package com.rjspies.daedalus.presentation.navigation
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.rjspies.daedalus.presentation.diagram.WeightDiagramScreen
 import com.rjspies.daedalus.presentation.history.WeightHistoryScreen
 
-fun NavGraphBuilder.navigationGraph(padding: PaddingValues) {
+fun NavGraphBuilder.navigationGraph(onOpenDrawer: () -> Unit) {
     composable<Route.Diagram> {
-        WeightDiagramScreen(scaffoldPadding = padding)
+        WeightDiagramScreen(onOpenDrawer = onOpenDrawer)
     }
     composable<Route.History> {
-        WeightHistoryScreen(padding)
+        WeightHistoryScreen(onOpenDrawer = onOpenDrawer)
     }
 }


### PR DESCRIPTION
## Summary

- Each screen reachable from the navigation drawer (`WeightDiagramScreen`, `WeightHistoryScreen`) now owns its own `CenterAlignedTopAppBar` with a menu icon to open the navigation drawer and a haze blur effect
- The `Scaffold` in `MainScreen` now only holds the `SnackbarHost` — the `NavigationBarBlur` and `hazeSource` on the `NavHost` remain in `MainScreen`
- `NavigationGraph` no longer passes `scaffoldPadding` to screens; instead an `onOpenDrawer` lambda is forwarded

## Test plan

- [ ] `./gradlew assembleDebug` compiles successfully
- [ ] `./gradlew detektMain detektTest` passes without errors
- [ ] `./gradlew test` all tests pass
- [ ] Navigation drawer opens via menu icon on both screens
- [ ] TopAppBar is centered on both screens
- [ ] Navigation between Diagram and History works correctly
- [ ] Snackbar displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)