### PR TITLE
Remove redundant screen-body titles from overview screens

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
@@ -100,6 +100,7 @@ fun WeightDiagramScreen(
                 .padding(scaffoldPadding)
                 .padding(bottom = Spacings.XXL),
         ) {
+            VerticalSpacerL()
             if (uiState.shouldShowInsertWeightDialog) {
                 val focusRequester = remember { FocusRequester() }
                 AlertDialog(
@@ -195,14 +196,7 @@ fun WeightDiagramScreen(
             }
 
             if (uiState.weights.isNotEmpty()) {
-                Column {
-                    Text(
-                        text = stringResource(R.string.weight_diagram_title),
-                        modifier = Modifier.horizontalSpacingM(),
-                        style = MaterialTheme.typography.displayMedium,
-                    )
-                    Box(Modifier.horizontalSpacingM()) { Chart(uiState.weights) }
-                }
+                Box(Modifier.horizontalSpacingM()) { Chart(uiState.weights) }
                 VerticalSpacerM()
                 WeightStatisticRow(
                     thirtyDayAverage = uiState.thirtyDayAverageWeight,

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FormatListNumbered
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -24,7 +22,7 @@ import com.rjspies.daedalus.domain.Weight
 import com.rjspies.daedalus.presentation.common.EmptyScreen
 import com.rjspies.daedalus.presentation.common.OverviewScreenContent
 import com.rjspies.daedalus.presentation.common.Spacings
-import com.rjspies.daedalus.presentation.common.VerticalSpacerS
+import com.rjspies.daedalus.presentation.common.VerticalSpacerL
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
 import com.rjspies.daedalus.presentation.common.verticalSpacingXXL
@@ -78,14 +76,7 @@ private fun Weights(
             start = Spacings.M,
         ),
         content = {
-            item {
-                Text(
-                    text = stringResource(R.string.weight_history_title),
-                    style = MaterialTheme.typography.displayMedium,
-                )
-                VerticalSpacerS()
-            }
-
+            item { VerticalSpacerL() }
             items(
                 items = weights,
                 key = { it.id },


### PR DESCRIPTION
## Summary

- After moving the `TopAppBar` into `OverviewScreenContent` (PR #340), both overview screens showed the screen title twice: once in the `CenterAlignedTopAppBar` and once as a large `displayMedium` text in the scrollable content body
- Removed the duplicate body titles (`"Deine Statistik"` from `WeightDiagramScreen`, `"Dein Verlauf"` from `WeightHistoryScreen`) along with their now-unused wrapper `Column` / `item { }` blocks and stale imports
- Added `VerticalSpacerL()` at the top of each screen's content area for visual breathing room below the TopAppBar

## Test plan

- [ ] Build succeeds: `./gradlew assembleDebug`
- [ ] No lint violations: `./gradlew detektMain detektTest`
- [ ] Launch app → open Statistik screen: title appears only in TopAppBar, content starts with correct spacing
- [ ] Launch app → open Verlauf screen: title appears only in TopAppBar, list starts with correct spacing
- [ ] Both empty-state screens still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)