### PR TITLE
Engineering menu with color and typography screens

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
@@ -9,10 +9,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ShowChart
+import androidx.compose.material.icons.rounded.Engineering
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
@@ -35,6 +38,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.rjspies.daedalus.BuildConfig
 import com.rjspies.daedalus.R
 import com.rjspies.daedalus.domain.SnackbarVisuals
 import com.rjspies.daedalus.presentation.common.Snackbar
@@ -63,9 +67,12 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
 
     val isDiagramSelected = currentRoute?.contains(Route.Diagram::class.qualifiedName.orEmpty()) == true
     val isHistorySelected = currentRoute?.contains(Route.History::class.qualifiedName.orEmpty()) == true
+    val isEngineeringTypographySelected = currentRoute?.contains(Route.EngineeringMenu::class.qualifiedName.orEmpty()) == true
 
     val hazeState = remember { HazeState() }
     val onOpenDrawer: () -> Unit = { coroutineScope.launch { drawerState.open() } }
+    val onNavigateUp: () -> Unit = { navigationController.navigateUp() }
+    val onNavigateTo: (Route) -> Unit = { navigationController.navigate(it) }
 
     LaunchedEffect(uiState.snackbarVisuals) {
         val visuals = uiState.snackbarVisuals
@@ -95,10 +102,11 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
                 Text(
                     text = stringResource(R.string.app_name),
                     modifier = Modifier.padding(horizontal = Spacings.M),
+                    style = MaterialTheme.typography.displaySmall,
                 )
                 VerticalSpacerL()
                 NavigationDrawerItem(
-                    label = { Text(stringResource(R.string.navigation_drawer_item_diagram)) },
+                    label = { Text(stringResource(R.string.navigation_drawer_item_diagram), style = MaterialTheme.typography.labelLarge) },
                     icon = { Icon(Icons.AutoMirrored.Rounded.ShowChart, contentDescription = null) },
                     selected = isDiagramSelected,
                     onClick = {
@@ -113,7 +121,7 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
                 )
                 VerticalSpacerXS()
                 NavigationDrawerItem(
-                    label = { Text(stringResource(R.string.navigation_drawer_item_history)) },
+                    label = { Text(stringResource(R.string.navigation_drawer_item_history), style = MaterialTheme.typography.labelLarge) },
                     icon = { Icon(Icons.Rounded.History, contentDescription = null) },
                     selected = isHistorySelected,
                     onClick = {
@@ -126,6 +134,23 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
                     },
                     modifier = Modifier.padding(horizontal = Spacings.M),
                 )
+                if (BuildConfig.DEBUG) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Spacings.S))
+                    NavigationDrawerItem(
+                        label = { Text(stringResource(R.string.navigation_drawer_item_engineering_menu), style = MaterialTheme.typography.labelLarge) },
+                        icon = { Icon(Icons.Rounded.Engineering, contentDescription = null) },
+                        selected = isEngineeringTypographySelected,
+                        onClick = {
+                            coroutineScope.launch { drawerState.close() }
+                            navigationController.navigate(Route.EngineeringMenu) {
+                                popUpTo(Route.Diagram) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        modifier = Modifier.padding(horizontal = Spacings.M),
+                    )
+                }
             }
         },
     ) {
@@ -143,7 +168,13 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
                 NavHost(
                     navController = navigationController,
                     startDestination = Route.Diagram,
-                    builder = { navigationGraph(onOpenDrawer) },
+                    builder = {
+                        navigationGraph(
+                            onOpenDrawer = onOpenDrawer,
+                            onNavigateUp = onNavigateUp,
+                            onNavigateTo = onNavigateTo,
+                        )
+                    },
                     modifier = Modifier.hazeSource(hazeState),
                 )
 

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/OverviewScreenContent.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/OverviewScreenContent.kt
@@ -40,7 +40,7 @@ fun OverviewScreenContent(
                     IconButton(onClick = onOpenDrawer) {
                         Icon(
                             imageVector = Icons.Rounded.Menu,
-                            contentDescription = stringResource(R.string.common_top_app_hamburger_menu_content_description),
+                            contentDescription = stringResource(R.string.common_top_app_bar_hamburger_menu_content_description),
                         )
                     }
                 },

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/SubScreenContent.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/SubScreenContent.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Menu
-import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -23,24 +23,24 @@ import dev.chrisbanes.haze.hazeSource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OverviewScreenContent(
+fun SubScreenContent(
     title: String,
-    onOpenDrawer: () -> Unit,
+    onNavigateUp: () -> Unit,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val hazeState = remember { HazeState() }
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
+            TopAppBar(
                 title = { Text(title) },
                 modifier = Modifier.daedalusHazeEffect(hazeState),
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
                 navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
+                    IconButton(onClick = onNavigateUp) {
                         Icon(
-                            imageVector = Icons.Rounded.Menu,
-                            contentDescription = stringResource(R.string.common_top_app_hamburger_menu_content_description),
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                            contentDescription = stringResource(R.string.common_top_app_bar_back_arrow_content_description),
                         )
                     }
                 },

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
@@ -74,6 +74,7 @@ import com.rjspies.daedalus.presentation.common.VerticalSpacerM
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.WeightChartEntry
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
+import com.rjspies.daedalus.presentation.common.verticalSpacingL
 import com.rjspies.daedalus.presentation.common.verticalSpacingM
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -98,9 +99,8 @@ fun WeightDiagramScreen(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
                 .padding(scaffoldPadding)
-                .padding(bottom = Spacings.XXL),
+                .verticalSpacingL(),
         ) {
-            VerticalSpacerL()
             if (uiState.shouldShowInsertWeightDialog) {
                 val focusRequester = remember { FocusRequester() }
                 AlertDialog(

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightStatisticCard.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightStatisticCard.kt
@@ -68,7 +68,7 @@ private fun WeightStatisticCard(
                 )
             } else {
                 Text(
-                    text = "\u2014",
+                    text = "\u2012",
                     style = MaterialTheme.typography.headlineMedium,
                 )
             }

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/EngineeringMenuScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/EngineeringMenuScreen.kt
@@ -1,0 +1,86 @@
+package com.rjspies.daedalus.presentation.engineeringmenu
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import com.rjspies.daedalus.R
+import com.rjspies.daedalus.presentation.common.HorizontalSpacerM
+import com.rjspies.daedalus.presentation.common.OverviewScreenContent
+import com.rjspies.daedalus.presentation.common.Spacings
+import com.rjspies.daedalus.presentation.common.horizontalSpacingM
+import com.rjspies.daedalus.presentation.common.horizontalSpacingS
+import com.rjspies.daedalus.presentation.common.verticalSpacingL
+import com.rjspies.daedalus.presentation.navigation.Route
+
+@Composable
+fun EngineeringMenuScreen(
+    onOpenDrawer: () -> Unit,
+    onNavigateTo: (Route) -> Unit,
+) {
+    OverviewScreenContent(
+        title = stringResource(R.string.navigation_top_bar_title_engineering_menu),
+        onOpenDrawer = onOpenDrawer,
+    ) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(scaffoldPadding),
+            verticalArrangement = Arrangement.spacedBy(Spacings.XS),
+        ) {
+            Entry(stringResource(R.string.engineering_menu_item_typography_label)) { onNavigateTo(Route.EngineeringMenuTypography) }
+            Entry(stringResource(R.string.engineering_menu_item_colors_label)) { onNavigateTo(Route.EngineeringMenuColors) }
+        }
+    }
+}
+
+@Composable
+fun Entry(
+    label: String,
+    onClick: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalSpacingM(),
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalSpacingS()
+                .verticalSpacingL(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = label,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.labelLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            HorizontalSpacerM()
+            Icon(
+                imageVector = Icons.Rounded.ChevronRight,
+                contentDescription = null,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/colors/ColorsScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/colors/ColorsScreen.kt
@@ -1,0 +1,265 @@
+package com.rjspies.daedalus.presentation.engineeringmenu.colors
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEach
+import com.rjspies.daedalus.R.string
+import com.rjspies.daedalus.presentation.common.Spacings
+import com.rjspies.daedalus.presentation.common.SubScreenContent
+import com.rjspies.daedalus.presentation.common.horizontalSpacingM
+import com.rjspies.daedalus.presentation.common.verticalSpacingL
+
+@Composable
+fun ColorsScreen(onNavigateUp: () -> Unit) {
+    SubScreenContent(stringResource(string.engineering_menu_typography_screen_title), onNavigateUp) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(scaffoldPadding)
+                .verticalSpacingL(),
+            verticalArrangement = Arrangement.spacedBy(Spacings.XS),
+        ) {
+            remember { EngineeringColor.entries }.fastForEach { textStyle ->
+                ColorSection(textStyle)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColorSection(color: EngineeringColor) {
+    Row(
+        modifier = Modifier.horizontalSpacingM(),
+        horizontalArrangement = Arrangement.spacedBy(Spacings.S),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(CircleShape)
+                .size(48.dp)
+                .background(color.color()),
+        )
+        Column {
+            Text(
+                text = color.title,
+                style = MaterialTheme.typography.labelLarge,
+                maxLines = 1,
+            )
+            Text(
+                text = "#${color.color().toArgb().toHexString(HexFormat.UpperCase)}",
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+private enum class EngineeringColor(
+    open val title: String,
+    open val color: @Composable () -> Color,
+) {
+    // Primary
+    Primary(
+        title = "primary",
+        color = { MaterialTheme.colorScheme.primary },
+    ),
+    OnPrimary(
+        title = "onPrimary",
+        color = { MaterialTheme.colorScheme.onPrimary },
+    ),
+    PrimaryContainer(
+        title = "primaryContainer",
+        color = { MaterialTheme.colorScheme.primaryContainer },
+    ),
+    OnPrimaryContainer(
+        title = "onPrimaryContainer",
+        color = { MaterialTheme.colorScheme.onPrimaryContainer },
+    ),
+    InversePrimary(
+        title = "inversePrimary",
+        color = { MaterialTheme.colorScheme.inversePrimary },
+    ),
+    PrimaryFixed(
+        title = "primaryFixed",
+        color = { MaterialTheme.colorScheme.primaryFixed },
+    ),
+    PrimaryFixedDim(
+        title = "primaryFixedDim",
+        color = { MaterialTheme.colorScheme.primaryFixedDim },
+    ),
+    OnPrimaryFixed(
+        title = "onPrimaryFixed",
+        color = { MaterialTheme.colorScheme.onPrimaryFixed },
+    ),
+    OnPrimaryFixedVariant(
+        title = "onPrimaryFixedVariant",
+        color = { MaterialTheme.colorScheme.onPrimaryFixedVariant },
+    ),
+
+    // Secondary
+    Secondary(
+        title = "secondary",
+        color = { MaterialTheme.colorScheme.secondary },
+    ),
+    OnSecondary(
+        title = "onSecondary",
+        color = { MaterialTheme.colorScheme.onSecondary },
+    ),
+    SecondaryContainer(
+        title = "secondaryContainer",
+        color = { MaterialTheme.colorScheme.secondaryContainer },
+    ),
+    OnSecondaryContainer(
+        title = "onSecondaryContainer",
+        color = { MaterialTheme.colorScheme.onSecondaryContainer },
+    ),
+    SecondaryFixed(
+        title = "secondaryFixed",
+        color = { MaterialTheme.colorScheme.secondaryFixed },
+    ),
+    SecondaryFixedDim(
+        title = "secondaryFixedDim",
+        color = { MaterialTheme.colorScheme.secondaryFixedDim },
+    ),
+    OnSecondaryFixed(
+        title = "onSecondaryFixed",
+        color = { MaterialTheme.colorScheme.onSecondaryFixed },
+    ),
+    OnSecondaryFixedVariant(
+        title = "onSecondaryFixedVariant",
+        color = { MaterialTheme.colorScheme.onSecondaryFixedVariant },
+    ),
+
+    // Tertiary
+    Tertiary(
+        title = "tertiary",
+        color = { MaterialTheme.colorScheme.tertiary },
+    ),
+    OnTertiary(
+        title = "onTertiary",
+        color = { MaterialTheme.colorScheme.onTertiary },
+    ),
+    TertiaryContainer(
+        title = "tertiaryContainer",
+        color = { MaterialTheme.colorScheme.tertiaryContainer },
+    ),
+    OnTertiaryContainer(
+        title = "onTertiaryContainer",
+        color = { MaterialTheme.colorScheme.onTertiaryContainer },
+    ),
+    TertiaryFixed(
+        title = "tertiaryFixed",
+        color = { MaterialTheme.colorScheme.tertiaryFixed },
+    ),
+    TertiaryFixedDim(
+        title = "tertiaryFixedDim",
+        color = { MaterialTheme.colorScheme.tertiaryFixedDim },
+    ),
+    OnTertiaryFixed(
+        title = "onTertiaryFixed",
+        color = { MaterialTheme.colorScheme.onTertiaryFixed },
+    ),
+    OnTertiaryFixedVariant(
+        title = "onTertiaryFixedVariant",
+        color = { MaterialTheme.colorScheme.onTertiaryFixedVariant },
+    ),
+
+    // Other
+    Error(
+        title = "error",
+        color = { MaterialTheme.colorScheme.error },
+    ),
+    OnError(
+        title = "onError",
+        color = { MaterialTheme.colorScheme.onError },
+    ),
+    ErrorContainer(
+        title = "errorContainer",
+        color = { MaterialTheme.colorScheme.errorContainer },
+    ),
+    OnErrorContainer(
+        title = "onErrorContainer",
+        color = { MaterialTheme.colorScheme.onErrorContainer },
+    ),
+    Outline(
+        title = "outline",
+        color = { MaterialTheme.colorScheme.outline },
+    ),
+    OutlineVariant(
+        title = "outlineVariant",
+        color = { MaterialTheme.colorScheme.outlineVariant },
+    ),
+    Background(
+        title = "background",
+        color = { MaterialTheme.colorScheme.background },
+    ),
+    OnBackground(
+        title = "onBackground",
+        color = { MaterialTheme.colorScheme.onBackground },
+    ),
+    Surface(
+        title = "surface",
+        color = { MaterialTheme.colorScheme.surface },
+    ),
+    OnSurface(
+        title = "onSurface",
+        color = { MaterialTheme.colorScheme.onSurface },
+    ),
+    InverseSurface(
+        title = "inverseSurface",
+        color = { MaterialTheme.colorScheme.inverseSurface },
+    ),
+    InverseOnSurface(
+        title = "inverseOnSurface",
+        color = { MaterialTheme.colorScheme.inverseOnSurface },
+    ),
+    SurfaceBright(
+        title = "surfaceBright",
+        color = { MaterialTheme.colorScheme.surfaceBright },
+    ),
+    SurfaceDim(
+        title = "surfaceDim",
+        color = { MaterialTheme.colorScheme.surfaceDim },
+    ),
+    SurfaceContainer(
+        title = "surfaceContainer",
+        color = { MaterialTheme.colorScheme.surfaceContainer },
+    ),
+    SurfaceContainerLow(
+        title = "surfaceContainerLow",
+        color = { MaterialTheme.colorScheme.surfaceContainerLow },
+    ),
+    SurfaceContainerLowest(
+        title = "surfaceContainerLowest",
+        color = { MaterialTheme.colorScheme.surfaceContainerLowest },
+    ),
+    SurfaceContainerHigh(
+        title = "surfaceContainerHigh",
+        color = { MaterialTheme.colorScheme.surfaceContainerHigh },
+    ),
+    SurfaceContainerHighest(
+        title = "surfaceContainerHighest",
+        color = { MaterialTheme.colorScheme.surfaceContainerHighest },
+    ),
+}

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/colors/ColorsScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/colors/ColorsScreen.kt
@@ -21,17 +21,29 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import com.rjspies.daedalus.R.string
+import com.rjspies.daedalus.presentation.DaedalusTheme
 import com.rjspies.daedalus.presentation.common.Spacings
 import com.rjspies.daedalus.presentation.common.SubScreenContent
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
 import com.rjspies.daedalus.presentation.common.verticalSpacingL
 
+private const val HexFormat = "#%02X"
+
+@Composable
+@PreviewLightDark
+fun ColorsScreenPreview() {
+    DaedalusTheme {
+        ColorsScreen(onNavigateUp = {})
+    }
+}
+
 @Composable
 fun ColorsScreen(onNavigateUp: () -> Unit) {
-    SubScreenContent(stringResource(string.engineering_menu_typography_screen_title), onNavigateUp) { scaffoldPadding ->
+    SubScreenContent(stringResource(string.engineering_menu_colors_screen_title), onNavigateUp) { scaffoldPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -67,7 +79,7 @@ private fun ColorSection(color: EngineeringColor) {
                 maxLines = 1,
             )
             Text(
-                text = "#${color.color().toArgb().toHexString(HexFormat.UpperCase)}",
+                text = String.format(HexFormat, color.color().toArgb()),
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
             )

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/typography/TypographyScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/typography/TypographyScreen.kt
@@ -15,12 +15,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.Hyphens
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.util.fastForEach
 import com.rjspies.daedalus.R.string
+import com.rjspies.daedalus.presentation.DaedalusTheme
 import com.rjspies.daedalus.presentation.common.Spacings
 import com.rjspies.daedalus.presentation.common.SubScreenContent
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
 import com.rjspies.daedalus.presentation.common.verticalSpacingL
+
+@Composable
+@PreviewLightDark
+fun TypographyScreenPreview() {
+    DaedalusTheme {
+        TypographyScreen(onNavigateUp = {})
+    }
+}
 
 @Composable
 fun TypographyScreen(onNavigateUp: () -> Unit) {

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/typography/TypographyScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/engineeringmenu/typography/TypographyScreen.kt
@@ -1,0 +1,125 @@
+package com.rjspies.daedalus.presentation.engineeringmenu.typography
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.Hyphens
+import androidx.compose.ui.util.fastForEach
+import com.rjspies.daedalus.R.string
+import com.rjspies.daedalus.presentation.common.Spacings
+import com.rjspies.daedalus.presentation.common.SubScreenContent
+import com.rjspies.daedalus.presentation.common.horizontalSpacingM
+import com.rjspies.daedalus.presentation.common.verticalSpacingL
+
+@Composable
+fun TypographyScreen(onNavigateUp: () -> Unit) {
+    SubScreenContent(stringResource(string.engineering_menu_typography_screen_title), onNavigateUp) { scaffoldPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(scaffoldPadding)
+                .verticalSpacingL(),
+            verticalArrangement = Arrangement.spacedBy(Spacings.L),
+        ) {
+            remember { EngineeringTextStyle.entries }.fastForEach { textStyle ->
+                TextStyleSection(textStyle)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TextStyleSection(style: EngineeringTextStyle) {
+    Column {
+        Text(
+            text = style.title,
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier.horizontalSpacingM(),
+        )
+        HorizontalDivider()
+        Text(
+            text = style.text,
+            style = style.style().copy(hyphens = Hyphens.Auto),
+            modifier = Modifier.horizontalSpacingM(),
+        )
+    }
+}
+
+private enum class EngineeringTextStyle(
+    open val title: String,
+    open val style: @Composable () -> TextStyle,
+    val text: String = "Der Hase springt über den faulen Hund.",
+) {
+    DisplayLarge(
+        title = "displayLarge",
+        style = { MaterialTheme.typography.displayLarge },
+    ),
+    DisplayMedium(
+        title = "displayMedium",
+        style = { MaterialTheme.typography.displayMedium },
+    ),
+    DisplaySmall(
+        title = "displaySmall",
+        style = { MaterialTheme.typography.displaySmall },
+    ),
+    HeadlineLarge(
+        title = "headlineLarge",
+        style = { MaterialTheme.typography.headlineLarge },
+    ),
+    HeadlineMedium(
+        title = "headlineMedium",
+        style = { MaterialTheme.typography.headlineMedium },
+    ),
+    HeadlineSmall(
+        title = "headlineSmall",
+        style = { MaterialTheme.typography.headlineSmall },
+    ),
+    TitleLarge(
+        title = "titleLarge",
+        style = { MaterialTheme.typography.titleLarge },
+    ),
+    TitleMedium(
+        title = "titleMedium",
+        style = { MaterialTheme.typography.titleMedium },
+    ),
+    TitleSmall(
+        title = "titleSmall",
+        style = { MaterialTheme.typography.titleSmall },
+    ),
+    BodyLarge(
+        title = "bodyLarge",
+        style = { MaterialTheme.typography.bodyLarge },
+    ),
+    BodyMedium(
+        title = "bodyMedium",
+        style = { MaterialTheme.typography.bodyMedium },
+    ),
+    BodySmall(
+        title = "bodySmall",
+        style = { MaterialTheme.typography.bodySmall },
+    ),
+    LabelLarge(
+        title = "labelLarge",
+        style = { MaterialTheme.typography.labelLarge },
+    ),
+    LabelMedium(
+        title = "labelMedium",
+        style = { MaterialTheme.typography.labelMedium },
+    ),
+    LabelSmall(
+        title = "labelSmall",
+        style = { MaterialTheme.typography.labelSmall },
+    ),
+}

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/history/WeightHistoryScreen.kt
@@ -22,7 +22,6 @@ import com.rjspies.daedalus.domain.Weight
 import com.rjspies.daedalus.presentation.common.EmptyScreen
 import com.rjspies.daedalus.presentation.common.OverviewScreenContent
 import com.rjspies.daedalus.presentation.common.Spacings
-import com.rjspies.daedalus.presentation.common.VerticalSpacerL
 import com.rjspies.daedalus.presentation.common.VerticalSpacerXS
 import com.rjspies.daedalus.presentation.common.horizontalSpacingM
 import com.rjspies.daedalus.presentation.common.verticalSpacingXXL
@@ -70,13 +69,12 @@ private fun Weights(
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(
-            top = scaffoldPadding.calculateTopPadding(),
+            top = scaffoldPadding.calculateTopPadding() + Spacings.L,
             end = Spacings.M,
-            bottom = scaffoldPadding.calculateBottomPadding() + Spacings.XXL,
+            bottom = scaffoldPadding.calculateBottomPadding() + Spacings.L,
             start = Spacings.M,
         ),
         content = {
-            item { VerticalSpacerL() }
             items(
                 items = weights,
                 key = { it.id },

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/NavigationGraph.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/NavigationGraph.kt
@@ -3,13 +3,32 @@ package com.rjspies.daedalus.presentation.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.rjspies.daedalus.presentation.diagram.WeightDiagramScreen
+import com.rjspies.daedalus.presentation.engineeringmenu.EngineeringMenuScreen
+import com.rjspies.daedalus.presentation.engineeringmenu.colors.ColorsScreen
+import com.rjspies.daedalus.presentation.engineeringmenu.typography.TypographyScreen
 import com.rjspies.daedalus.presentation.history.WeightHistoryScreen
 
-fun NavGraphBuilder.navigationGraph(onOpenDrawer: () -> Unit) {
+fun NavGraphBuilder.navigationGraph(
+    onOpenDrawer: () -> Unit,
+    onNavigateUp: () -> Unit,
+    onNavigateTo: (Route) -> Unit,
+) {
     composable<Route.Diagram> {
         WeightDiagramScreen(onOpenDrawer = onOpenDrawer)
     }
     composable<Route.History> {
         WeightHistoryScreen(onOpenDrawer = onOpenDrawer)
+    }
+    composable<Route.EngineeringMenu> {
+        EngineeringMenuScreen(
+            onOpenDrawer = onOpenDrawer,
+            onNavigateTo = onNavigateTo,
+        )
+    }
+    composable<Route.EngineeringMenuTypography> {
+        TypographyScreen(onNavigateUp)
+    }
+    composable<Route.EngineeringMenuColors> {
+        ColorsScreen(onNavigateUp)
     }
 }

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/Route.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/Route.kt
@@ -8,4 +8,13 @@ sealed class Route {
 
     @Serializable
     data object History : Route()
+
+    @Serializable
+    data object EngineeringMenu : Route()
+
+    @Serializable
+    data object EngineeringMenuTypography : Route()
+
+    @Serializable
+    data object EngineeringMenuColors : Route()
 }

--- a/app/src/main/res/values/strings_common.xml
+++ b/app/src/main/res/values/strings_common.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="common_snackbar_dismiss_action_icon_content_description">Schließen-Knopf</string>
+    <string name="common_top_app_hamburger_menu_content_description">Navigation öffnen</string>
+    <string name="common_top_app_bar_back_arrow_content_description">Zurücknavigieren</string>
 </resources>

--- a/app/src/main/res/values/strings_common.xml
+++ b/app/src/main/res/values/strings_common.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="common_snackbar_dismiss_action_icon_content_description">Schließen-Knopf</string>
-    <string name="common_top_app_hamburger_menu_content_description">Navigation öffnen</string>
+    <string name="common_top_app_bar_hamburger_menu_content_description">Navigation öffnen</string>
     <string name="common_top_app_bar_back_arrow_content_description">Zurücknavigieren</string>
 </resources>

--- a/app/src/main/res/values/strings_engineering_menu.xml
+++ b/app/src/main/res/values/strings_engineering_menu.xml
@@ -1,0 +1,10 @@
+<resources>
+    <string name="engineering_menu_item_typography_label">Typographie</string>
+    <string name="engineering_menu_item_colors_label">Farben</string>
+
+    <!-- Typography entry -->
+    <string name="engineering_menu_typography_screen_title">Typographie</string>
+
+    <!-- Colors entry -->
+    <string name="engineering_menu_colors_screen_title">Farben</string>
+</resources>

--- a/app/src/main/res/values/strings_navigation.xml
+++ b/app/src/main/res/values/strings_navigation.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="navigation_drawer_open_content_description">Navigation öffnen</string>
     <string name="navigation_top_bar_title_diagram">Statistik</string>
     <string name="navigation_top_bar_title_history">Verlauf</string>
     <string name="navigation_drawer_item_diagram">Statistik</string>
     <string name="navigation_drawer_item_history">Verlauf</string>
+    <string name="navigation_drawer_section_engineering">Engineering</string>
+    <string name="navigation_drawer_item_engineering_menu">Ingenieursmenü</string>
+    <string name="navigation_top_bar_title_engineering_menu">Ingenieursmenü</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add new EngineeringMenu entry to main navigation drawer
- Add ColorsScreen for managing the app's color palette
- Add TypographyScreen for managing font settings
- Add route for the engineering menu

## Test plan
- [ ] Open navigation drawer and verify engineering menu entry is visible
- [ ] Tap engineering menu and verify it opens correctly
- [ ] Verify ColorsScreen displays the color palette
- [ ] Verify TypographyScreen displays font options

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>