### PR TITLE
Replace insert-weight button with FloatingActionButton in diagram screen

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/OverviewScreenContent.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/common/OverviewScreenContent.kt
@@ -26,6 +26,7 @@ import dev.chrisbanes.haze.hazeSource
 fun OverviewScreenContent(
     title: String,
     onOpenDrawer: () -> Unit,
+    floatingActionButton: @Composable () -> Unit = {},
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val hazeState = remember { HazeState() }
@@ -46,6 +47,7 @@ fun OverviewScreenContent(
                 },
             )
         },
+        floatingActionButton = floatingActionButton,
         content = { scaffoldPadding ->
             Box(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightDiagramScreen.kt
@@ -21,10 +21,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Addchart
 import androidx.compose.material.icons.rounded.Timeline
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -93,6 +94,16 @@ fun WeightDiagramScreen(
     OverviewScreenContent(
         title = stringResource(R.string.navigation_top_bar_title_diagram),
         onOpenDrawer = onOpenDrawer,
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ShowInsertWeightDialog) },
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Add,
+                    contentDescription = stringResource(R.string.weight_diagram_floating_action_button_content_description),
+                )
+            }
+        },
     ) { scaffoldPadding ->
         Column(
             modifier = Modifier
@@ -218,32 +229,23 @@ fun WeightDiagramScreen(
             }
 
             VerticalSpacerL()
-            Column(verticalArrangement = Arrangement.spacedBy(Spacings.XS)) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalSpacingM(),
-                    horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
-                ) {
-                    OutlinedButton(
-                        onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ImportClicked) },
-                        modifier = Modifier.weight(1f),
-                        content = { Text(stringResource(R.string.weight_diagram_button_import_weights_title)) },
-                        enabled = !uiState.isImporting,
-                    )
-                    OutlinedButton(
-                        onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ExportClicked) },
-                        modifier = Modifier.weight(1f),
-                        content = { Text(stringResource(R.string.weight_diagram_button_export_weights_title)) },
-                        enabled = !uiState.isExporting,
-                    )
-                }
-                Button(
-                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ShowInsertWeightDialog) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalSpacingM(),
-                    content = { Text(stringResource(R.string.weight_diagram_button_insert_weight_title)) },
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalSpacingM(),
+                horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
+            ) {
+                OutlinedButton(
+                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ImportClicked) },
+                    modifier = Modifier.weight(1f),
+                    content = { Text(stringResource(R.string.weight_diagram_button_import_weights_title)) },
+                    enabled = !uiState.isImporting,
+                )
+                OutlinedButton(
+                    onClick = { viewModel.onEvent(WeightDiagramViewModel.Event.ExportClicked) },
+                    modifier = Modifier.weight(1f),
+                    content = { Text(stringResource(R.string.weight_diagram_button_export_weights_title)) },
+                    enabled = !uiState.isExporting,
                 )
             }
         }

--- a/app/src/main/res/values/strings_weight_diagram.xml
+++ b/app/src/main/res/values/strings_weight_diagram.xml
@@ -7,6 +7,7 @@
     <string name="weight_diagram_statistic_thirty_day_average_label">Ø 30 Tage</string>
     <string name="weight_diagram_statistic_latest_weight_label">Zuletzt eingetragen</string>
     <string name="weight_diagram_button_insert_weight_title">Hinzufügen</string>
+    <string name="weight_diagram_floating_action_button_content_description">Gewichtseintrag hinzufügen</string>
     <string name="weight_diagram_button_export_weights_title">Exportieren</string>
     <string name="weight_diagram_button_import_weights_title">Importieren</string>
     <string name="snackbar_insert_weight_success">Gewicht erfolgreich hinzugefügt</string>


### PR DESCRIPTION
## Summary

- Adds an optional `floatingActionButton` slot to `OverviewScreenContent`, forwarded to the underlying `Scaffold`
- Migrates the add-weight action in `WeightDiagramScreen` from an inline `Button` to a `FloatingActionButton` passed through that slot
- Removes the wrapping `Column` from the import/export button area, leaving only the `Row`
- Adds a string resource for the FAB content description

## Test plan

- [ ] Open the diagram screen and verify the FAB appears in the bottom-right corner
- [ ] Tap the FAB and confirm the insert-weight dialog opens
- [ ] Verify import and export buttons still appear correctly below the chart
- [ ] Confirm no FAB is shown on other overview screens (history screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)