### PR TITLE
Remove ElevatedCard from weight statistic items in diagram screen

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightStatisticCard.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightStatisticCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,27 +50,25 @@ private fun WeightStatisticCard(
     value: Float?,
     modifier: Modifier = Modifier,
 ) {
-    ElevatedCard(modifier = modifier) {
-        Column(modifier = Modifier.padding(Spacings.M)) {
+    Column(modifier = modifier.padding(Spacings.M)) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        if (value != null) {
+            val unitStyle = MaterialTheme.typography.bodySmall.toSpanStyle()
             Text(
-                text = label,
-                style = MaterialTheme.typography.bodySmall,
+                text = buildAnnotatedString {
+                    append("%.1f".format(value))
+                    withStyle(unitStyle) { append(" kg") }
+                },
+                style = MaterialTheme.typography.headlineMedium,
             )
-            if (value != null) {
-                val unitStyle = MaterialTheme.typography.bodySmall.toSpanStyle()
-                Text(
-                    text = buildAnnotatedString {
-                        append("%.1f".format(value))
-                        withStyle(unitStyle) { append(" kg") }
-                    },
-                    style = MaterialTheme.typography.headlineMedium,
-                )
-            } else {
-                Text(
-                    text = "\u2012",
-                    style = MaterialTheme.typography.headlineMedium,
-                )
-            }
+        } else {
+            Text(
+                text = "\u2012",
+                style = MaterialTheme.typography.headlineMedium,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightStatisticRow.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/diagram/WeightStatisticRow.kt
@@ -31,12 +31,12 @@ internal fun WeightStatisticRow(
             .horizontalSpacingM(),
         horizontalArrangement = Arrangement.spacedBy(Spacings.XS),
     ) {
-        WeightStatisticCard(
+        WeightStatisticItem(
             label = stringResource(R.string.weight_diagram_statistic_thirty_day_average_label),
             value = thirtyDayAverage,
             modifier = Modifier.weight(1f),
         )
-        WeightStatisticCard(
+        WeightStatisticItem(
             label = stringResource(R.string.weight_diagram_statistic_latest_weight_label),
             value = latestWeight,
             modifier = Modifier.weight(1f),
@@ -45,7 +45,7 @@ internal fun WeightStatisticRow(
 }
 
 @Composable
-private fun WeightStatisticCard(
+private fun WeightStatisticItem(
     label: String,
     value: Float?,
     modifier: Modifier = Modifier,

--- a/config/detekt/baseline-debug.xml
+++ b/config/detekt/baseline-debug.xml
@@ -3,6 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>LongParameterList:WeightDiagramViewModel.kt$WeightDiagramViewModel$( getWeightsAscending: GetWeightsAscendingUseCase, getThirtyDayAverageWeight: GetThirtyDayAverageWeightUseCase, private val insertWeight: InsertWeightUseCase, private val exportWeights: ExportWeightsUseCase, private val importWeights: ImportWeightsUseCase, private val showSnackbar: ShowSnackbarUseCase, private val stringProvider: StringProvider, )</ID>
-    <ID>UnusedPrivateMember:WeightStatisticCard.kt$@PreviewLightDark @Composable private fun WeightStatisticRowPreview( @PreviewParameter(WeightStatisticRowPreviewProvider::class) data: WeightStatisticRowPreviewData, )</ID>
+    <ID>UnusedPrivateMember:WeightStatisticRow.kt$@PreviewLightDark @Composable private fun WeightStatisticRowPreview( @PreviewParameter(WeightStatisticRowPreviewProvider::class) data: WeightStatisticRowPreviewData, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/config/detekt/baseline-release.xml
+++ b/config/detekt/baseline-release.xml
@@ -3,6 +3,6 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>LongParameterList:WeightDiagramViewModel.kt$WeightDiagramViewModel$( getWeightsAscending: GetWeightsAscendingUseCase, getThirtyDayAverageWeight: GetThirtyDayAverageWeightUseCase, private val insertWeight: InsertWeightUseCase, private val exportWeights: ExportWeightsUseCase, private val importWeights: ImportWeightsUseCase, private val showSnackbar: ShowSnackbarUseCase, private val stringProvider: StringProvider, )</ID>
-    <ID>UnusedPrivateMember:WeightStatisticCard.kt$@PreviewLightDark @Composable private fun WeightStatisticRowPreview( @PreviewParameter(WeightStatisticRowPreviewProvider::class) data: WeightStatisticRowPreviewData, )</ID>
+    <ID>UnusedPrivateMember:WeightStatisticRow.kt$@PreviewLightDark @Composable private fun WeightStatisticRowPreview( @PreviewParameter(WeightStatisticRowPreviewProvider::class) data: WeightStatisticRowPreviewData, )</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## Summary
- Removes `ElevatedCard` wrapper from `WeightStatisticCard`
- Replaces with plain `Column` — content (label, value, fallback dash) unchanged

## Test plan
- [ ] Open diagram screen with weights — statistic row visible, no card chrome
- [ ] Open diagram screen empty — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)