### PR TITLE
Disable navigation drawer swipe gesture on sub-screens

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/MainScreen.kt
@@ -65,9 +65,10 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
 
     val currentRoute = currentBackStackEntry?.run { destination.route }
 
-    val isDiagramSelected = currentRoute?.contains(Route.Diagram::class.qualifiedName.orEmpty()) == true
-    val isHistorySelected = currentRoute?.contains(Route.History::class.qualifiedName.orEmpty()) == true
-    val isEngineeringTypographySelected = currentRoute?.contains(Route.EngineeringMenu::class.qualifiedName.orEmpty()) == true
+    val isDiagramSelected = currentRoute == Route.Diagram::class.qualifiedName
+    val isHistorySelected = currentRoute == Route.History::class.qualifiedName
+    val isEngineeringTypographySelected = currentRoute == Route.EngineeringMenu::class.qualifiedName
+    val isOverviewRoute = isDiagramSelected || isHistorySelected || isEngineeringTypographySelected
 
     val hazeState = remember { HazeState() }
     val onOpenDrawer: () -> Unit = { coroutineScope.launch { drawerState.open() } }
@@ -96,6 +97,7 @@ fun MainScreen(viewModel: MainViewModel = koinViewModel()) {
 
     ModalNavigationDrawer(
         drawerState = drawerState,
+        gesturesEnabled = isOverviewRoute,
         drawerContent = {
             ModalDrawerSheet {
                 VerticalSpacerXS()


### PR DESCRIPTION
## Summary

- Route matching used `contains()`, causing `EngineeringMenuTypography` and `EngineeringMenuColors` to falsely match the `EngineeringMenu` route check
- This kept `gesturesEnabled = true` on sub-screens, making the drawer swipeable where it shouldn't be
- Switch route checks to equality (`==`) and gate `gesturesEnabled` on `isOverviewRoute` — swipe only works on Diagram, History, and EngineeringMenu screens

## Test plan

- [ ] Swipe from left edge on Diagram / History / EngineeringMenu → drawer opens
- [ ] Hamburger button on overview screens → drawer opens
- [ ] Swipe from left edge on Typography / Colors → drawer does NOT open

🤖 Generated with [Claude Code](https://claude.com/claude-code)