### PR TITLE
Fix startup crash and bump version to 2.4.1

### DIFF
--- a/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/Route.kt
+++ b/app/src/main/kotlin/com/rjspies/daedalus/presentation/navigation/Route.kt
@@ -2,6 +2,7 @@ package com.rjspies.daedalus.presentation.navigation
 
 import kotlinx.serialization.Serializable
 
+@Serializable
 sealed class Route {
     @Serializable
     data object Diagram : Route()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ ksp = "2.3.7"
 compileSdk = "36"
 targetSdk = "35"
 minSdk = "29"
-versionName = "2.4"
+versionName = "2.4.1"
 versionCodeOffset = "200000"
 namespace = "com.rjspies.daedalus"
 


### PR DESCRIPTION
## Summary

- Add `@Serializable` to `Route` sealed class — missing annotation caused navigation to crash at startup
- Bump version name from 2.4 to 2.4.1

## Test plan

- [ ] Launch app and verify no startup crash
- [ ] Navigate between Diagram and History screens