### PR TITLE
Keep Route class from R8 shrinking

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,3 +22,6 @@
 
 -printusage r8-usage-report.txt
 -printseeds r8-seeds-report.txt
+
+-keep class com.rjspies.daedalus.presentation.navigation.Route { *; }
+-keep class com.rjspies.daedalus.presentation.navigation.Route$* { *; }


### PR DESCRIPTION
## Summary

- Add ProGuard rules to keep `Route` sealed class and all nested `data object` subclasses
- Required for kotlinx.serialization reflection on `@Serializable` route types at runtime

## Test plan

- [ ] Build release APK and verify navigation between screens works
- [ ] Confirm no `ClassNotFoundException` or serialization errors in logcat