### PR TITLE
Bump version to 2.4.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ ksp = "2.3.7"
 compileSdk = "36"
 targetSdk = "35"
 minSdk = "29"
-versionName = "2.4.1"
+versionName = "2.4.2"
 versionCodeOffset = "200000"
 namespace = "com.rjspies.daedalus"
 


### PR DESCRIPTION
## Summary

- Bump `versionName` from 2.4.1 to 2.4.2

## Test plan

- [ ] Verify version name shows 2.4.2 in app settings / about screen